### PR TITLE
Fix config error

### DIFF
--- a/app/code/community/Welance/Kraken/Model/Observer.php
+++ b/app/code/community/Welance/Kraken/Model/Observer.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
 
 class Welance_Kraken_Model_Observer
 {


### PR DESCRIPTION
This fixes the following error when saving configuration:

```
Cannot send headers; headers already sent in /var/www/app/code/community/Welance/Kraken/Model/Observer.php, line 1

#0 /var/www/lib/Zend/Controller/Response/Abstract.php(148): Zend_Controller_Response_Abstract->canSendHeaders(true)
#1 /var/www/app/code/core/Mage/Core/Controller/Response/Http.php(107): Zend_Controller_Response_Abstract->setRedirect('http://test.v...', 302)
#2 /var/www/app/code/core/Mage/Adminhtml/Controller/Action.php(358): Mage_Core_Controller_Response_Http->setRedirect('http://test.v...')
#3 /var/www/app/code/core/Mage/Adminhtml/controllers/System/ConfigController.php(195): Mage_Adminhtml_Controller_Action->_redirect('*/*/edit', Array)
#4 /var/www/app/code/core/Mage/Core/Controller/Varien/Action.php(418): Mage_Adminhtml_System_ConfigController->saveAction()
#5 /var/www/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch('save')
#6 /var/www/app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#7 /var/www/app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch()
#8 /var/www/app/Mage.php(691): Mage_Core_Model_App->run(Array)
#9 /var/www/index.php(84): Mage::run('', 'store')
#10 {main}
```